### PR TITLE
only add error listener once, resolves #8

### DIFF
--- a/solr-security-proxy.js
+++ b/solr-security-proxy.js
@@ -62,14 +62,21 @@ SolrSecurityProxy.createServer = function(options) {
 
   // console.log(options);
 
+  var proxyErrorListenerYetToBeAdded = true;
+
   // adapted from http://git.io/k5dCxQ
   var server = httpProxy.createServer(function(request, response, proxy) {
-    if (options.validator(request, options)) {
-      proxy.proxyRequest(request, response, options.backend);
+
+    if (proxyErrorListenerYetToBeAdded) {
       proxy.on('proxyError', function(err, req, res) {
         res.writeHead(502, {  'Content-Type': 'text/plain' });
         res.end('Proxy error: ' + err);
       });
+      proxyErrorListenerYetToBeAdded = false;
+    }
+
+    if (options.validator(request, options)) {
+      proxy.proxyRequest(request, response, options.backend);
     } else {
       response.writeHead(403, 'Illegal request');
       response.write("solrProxy: access denied\n");

--- a/test/test-with-mock-backend.js
+++ b/test/test-with-mock-backend.js
@@ -1,10 +1,19 @@
 var vows = require('vows'),
     http = require('http'),
+    url = require('url'),
     SolrSecurityProxy = require('../solr-security-proxy.js'),
     vowsHelper = require('./vows-helper.js');
 
 var startSimpleBackendServer = function(port) {
   http.createServer(function (req, res) {
+    var params = url.parse(req.url,true).query;
+
+    if (params.proxyError) {
+        // Send something invalid to trigger proxyError event
+        res.writeHead('abc');
+        res.end();
+        return;
+    }
     res.writeHead(200, {'Content-Type': 'text/html'});
     res.write('mock backend processed request');
     res.end();
@@ -14,5 +23,5 @@ var startSimpleBackendServer = function(port) {
 startSimpleBackendServer(9090);
 SolrSecurityProxy.start(8008, { backend: { port: 9090}});
 
-var batch = vowsHelper.testProxyBatch( 'http://localhost:8008/solr/');
+var batch = vowsHelper.testProxyBatch('http://localhost:8008/solr/', {mocked: true});
 suite = vows.describe('test-with-mock-backend').addBatch(batch).export(module);

--- a/test/vows-helper.js
+++ b/test/vows-helper.js
@@ -24,17 +24,37 @@ var respondsWith = function(status, solrPath) {
   return context;
 }
 
-exports.testProxyBatch = function(proxyUrl) {
+exports.testProxyBatch = function(proxyUrl, options) {
+  // options:
+  //    mocked: set to true to run tests that depend on the Solr proxy being mocked
+  options = options || {};
+
   var proxyRespondsWith = function(status) {
     return respondsWith(status, proxyUrl);
   }
-  return {
+  var rv = {
     'POST select':                  proxyRespondsWith(403),
     'GET  select?q=balloon':        proxyRespondsWith(200),
     'GET  admin':                   proxyRespondsWith(403),
     'GET  update':                  proxyRespondsWith(403),
     'GET  select?qt=/update':       proxyRespondsWith(403),
     'GET  select?stream.url=EVIL':  proxyRespondsWith(403),
-    'GET  select?stream.body=EVIL': proxyRespondsWith(403)
+    'GET  select?stream.body=EVIL': proxyRespondsWith(403),
+    'GET  select?q=2':              proxyRespondsWith(200),
+    'GET  select?q=3':              proxyRespondsWith(200),
+    'GET  select?q=4':              proxyRespondsWith(200),
+    'GET  select?q=5':              proxyRespondsWith(200),
+    'GET  select?q=6':              proxyRespondsWith(200),
+    'GET  select?q=7':              proxyRespondsWith(200),
+    'GET  select?q=8':              proxyRespondsWith(200),
+    'GET  select?q=9':              proxyRespondsWith(200),
+    'GET  select?q=10':             proxyRespondsWith(200),
+    'GET  select?q=11':             proxyRespondsWith(200)
   };
+
+  if (options.mocked) {
+    rv['GET  select?proxyError=true'] = proxyRespondsWith(502);
+  }
+
+  return rv;
 }


### PR DESCRIPTION
* Adds test for proxyError event in mocked Solr server test mode
* Adds a bunch of valid tests so that a warning is triggered if the `proxyError` is being added more than once
